### PR TITLE
Configura o Docker para usar o systemd 

### DIFF
--- a/install_k8s/roles/install_k8s/tasks/install.yml
+++ b/install_k8s/roles/install_k8s/tasks/install.yml
@@ -17,6 +17,19 @@
     state: absent
   register: removendo_script
 
+- name: Configurado o docker para usar o Systemd
+  ansible.builtin.lineinfile:
+    path: /etc/docker/daemon.json
+    line: "{{ docker_json }}"
+    create: yes
+    mode: "0755"
+
+- name: Restartando o Docker Daemon
+  systemd:
+    state: restarted
+    daemon_reload: yes
+    name: docker
+
 - name: Adicionando as chaves do repo apt do k8s
   apt_key:
     url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
@@ -36,4 +49,3 @@
     - kubeadm
     - kubectl
   notify: Restart Kubelet
-

--- a/install_k8s/roles/install_k8s/vars/main.yml
+++ b/install_k8s/roles/install_k8s/vars/main.yml
@@ -2,3 +2,13 @@
 # vars file for install-k8s
 dst_docker_script: /tmp/install_docker.sh
 url_docker_script: https://get.docker.com
+docker_json: '
+{
+  "exec-opts": ["native.cgroupdriver=systemd"],
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "100m"
+  },
+  "storage-driver": "overlay2"
+}
+'

--- a/provisioning/roles/criando_instancias/vars/main.yaml
+++ b/provisioning/roles/criando_instancias/vars/main.yaml
@@ -2,7 +2,7 @@
 # vars file for criando-instancias
 instance_type: t2.medium
 sec_group_name: giropops
-image: ami-0b418580298265d5c
+image: ami-09e67e426f25ce0d7
 keypair: ansible-live
 region: eu-central-1
 count: 3


### PR DESCRIPTION
# Problemas

- O Kubeadm não conseguia iniciar o cluster
Explicação da solução: [Kubenetes.io](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#docker)

- O AMI do provisioning não existia mais e dava erro ao executar o playbook.
